### PR TITLE
[WiP] Adds traffic route rules appliers

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -11,7 +11,7 @@ needed.
 = Usage
 
 Please take a look at the tests in `istio-model/src/test/java` to see how the API can be used. You can also take a look at the
-https://github.com/metacosm/istio-test-dsl project which demonstrates an end-to-end scenario using the Fabric8 OpenShift client
+https://github.com/metacosm/istio-test-dsl project which demonstrates an end-to-end scenario using the Fabric8 OpenShift adapter
 and this API to send Istio artifacts to a running OpenShift cluster configured on which Istio is set up.
 
 = Building instructions

--- a/istio-applier/pom.xml
+++ b/istio-applier/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2011 Red Hat, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>me.snowdrop</groupId>
+    <artifactId>istio-java-api</artifactId>
+    <version>0.3-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>istio-applier</artifactId>
+  <packaging>jar</packaging>
+
+  <name>Snowdrop :: Istio Java API :: Applier</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>me.snowdrop</groupId>
+      <artifactId>istio-model</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>kubernetes-client</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>kubernetes-openshift-uberjar</artifactId>
+      <classifier>versioned</classifier>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/istio-applier/src/main/java/me/snowdrop/istio/applier/Adapter.java
+++ b/istio-applier/src/main/java/me/snowdrop/istio/applier/Adapter.java
@@ -1,0 +1,10 @@
+package me.snowdrop.istio.applier;
+
+import io.fabric8.kubernetes.api.model.Doneable;
+import me.snowdrop.istio.api.model.IstioResource;
+
+public interface Adapter {
+
+    IstioResource createCustomResource(String customResourceDefinition, IstioResource istioResource, Class<? extends Doneable> done);
+
+}

--- a/istio-applier/src/main/java/me/snowdrop/istio/applier/Applier.java
+++ b/istio-applier/src/main/java/me/snowdrop/istio/applier/Applier.java
@@ -1,0 +1,11 @@
+package me.snowdrop.istio.applier;
+
+import java.util.Map;
+import me.snowdrop.istio.api.model.IstioResource;
+
+public interface Applier {
+
+    boolean canApply(String kind);
+    IstioResource apply(Map<String, Object> resource);
+
+}

--- a/istio-applier/src/main/java/me/snowdrop/istio/applier/DestinationPolicyApplier.java
+++ b/istio-applier/src/main/java/me/snowdrop/istio/applier/DestinationPolicyApplier.java
@@ -1,0 +1,30 @@
+package me.snowdrop.istio.applier;
+
+import java.util.Map;
+import me.snowdrop.istio.api.model.IstioResource;
+import me.snowdrop.istio.api.model.v1.routing.DestinationPolicy;
+import me.snowdrop.istio.api.model.v1.routing.DoneableDestinationPolicy;
+
+public class DestinationPolicyApplier implements Applier {
+
+    private static final String DESTINATION_POLICY_KIND = "DestinationPolicy";
+    static final String DESTINATION_POLICY_CUSTOM_RESOURCE_DEFINITION = "destinationpolicies.config.istio.io";
+
+    private final Adapter adapter;
+
+    public DestinationPolicyApplier(Adapter adapter) {
+        this.adapter = adapter;
+    }
+
+    @Override
+    public boolean canApply(String kind) {
+        return DESTINATION_POLICY_KIND.equals(kind);
+    }
+
+    @Override
+    public IstioResource apply(Map<String, Object> resource) {
+
+        final DestinationPolicy destinationPolicy = ObjectMapperFactory.objectMapper.convertValue(resource, DestinationPolicy.class);
+        return this.adapter.createCustomResource(DESTINATION_POLICY_CUSTOM_RESOURCE_DEFINITION, destinationPolicy, DoneableDestinationPolicy.class);
+    }
+}

--- a/istio-applier/src/main/java/me/snowdrop/istio/applier/EgressRuleApplier.java
+++ b/istio-applier/src/main/java/me/snowdrop/istio/applier/EgressRuleApplier.java
@@ -1,0 +1,32 @@
+package me.snowdrop.istio.applier;
+
+import java.util.Map;
+import me.snowdrop.istio.api.model.IstioResource;
+import me.snowdrop.istio.api.model.v1.routing.DoneableEgressRule;
+import me.snowdrop.istio.api.model.v1.routing.EgressRule;
+
+public class EgressRuleApplier implements Applier {
+
+    private static final String EGRESS_RULE_KIND = "EgressRule";
+    static final String EGRESS_RULE_CUSTOM_RESOURCE_DEFINITION = "egressrules.config.istio.io";
+
+    private final Adapter adapter;
+
+    public EgressRuleApplier(Adapter adapter) {
+        this.adapter = adapter;
+    }
+
+    @Override
+    public boolean canApply(String kind) {
+        return EGRESS_RULE_KIND.equals(kind);
+    }
+
+    @Override
+    public IstioResource apply(Map<String, Object> resource) {
+
+        final EgressRule
+            egressRule = ObjectMapperFactory.objectMapper.convertValue(resource, EgressRule.class);
+        return this.adapter.createCustomResource(EGRESS_RULE_CUSTOM_RESOURCE_DEFINITION, egressRule, DoneableEgressRule.class);
+    }
+
+}

--- a/istio-applier/src/main/java/me/snowdrop/istio/applier/IstioExecutor.java
+++ b/istio-applier/src/main/java/me/snowdrop/istio/applier/IstioExecutor.java
@@ -1,0 +1,59 @@
+package me.snowdrop.istio.applier;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import me.snowdrop.istio.api.model.IstioResource;
+
+public class IstioExecutor {
+
+    private static final String KIND = "kind";
+    private List<Applier> istioResources = new ArrayList<>();
+
+    public IstioExecutor(Adapter client) {
+        istioResources.addAll(Arrays.asList(
+            new RouteRuleApplier(client),
+            new DestinationPolicyApplier(client),
+            new EgressRuleApplier(client)));
+    }
+
+    public Optional<IstioResource> registerCustomResource(final String resource) {
+        try {
+            final Map<String, Object> resourceYaml = ObjectMapperFactory.objectMapper.readValue(resource, Map.class);
+            return apply(resourceYaml);
+        } catch (IOException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    public Optional<IstioResource> registerCustomResource(final InputStream resource) {
+        try {
+            final Map<String, Object> resourceYaml = ObjectMapperFactory.objectMapper.readValue(resource, Map.class);
+            return apply(resourceYaml);
+        } catch (IOException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    private Optional<IstioResource> apply(Map<String, Object> resourceYaml) {
+        if (resourceYaml.containsKey(KIND)) {
+
+            final Optional<Applier> applier = istioResources.stream()
+                .filter(a -> a.canApply((String) resourceYaml.get(KIND)))
+                .findFirst();
+
+           if (applier.isPresent()) {
+               return Optional.of(applier.get().apply(resourceYaml));
+            }
+
+            return Optional.empty();
+
+        } else {
+            throw new IllegalArgumentException(String.format("%s is not specified in provided resource.", KIND));
+        }
+    }
+}

--- a/istio-applier/src/main/java/me/snowdrop/istio/applier/KubernetesAdapter.java
+++ b/istio-applier/src/main/java/me/snowdrop/istio/applier/KubernetesAdapter.java
@@ -1,0 +1,35 @@
+package me.snowdrop.istio.applier;
+
+import io.fabric8.kubernetes.api.model.Doneable;
+import io.fabric8.kubernetes.api.model.KubernetesResourceList;
+import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinition;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import me.snowdrop.istio.api.model.IstioResource;
+
+public class KubernetesAdapter implements Adapter {
+
+    private KubernetesClient client;
+
+    public KubernetesAdapter(KubernetesClient kubernetesClient) {
+        this.client = kubernetesClient;
+    }
+
+    @Override
+    public IstioResource createCustomResource(String customResourceDef, IstioResource istioResource,
+        Class<? extends Doneable> done) {
+
+        final CustomResourceDefinition customResourceDefinition =
+            client.customResourceDefinitions().withName(customResourceDef).get();
+
+        if (customResourceDefinition == null) {
+            throw new IllegalArgumentException(String.format("Custom Resource Definition %s is not found in cluster %s",
+                customResourceDef, client.getMasterUrl()));
+        }
+
+        final IstioResource createdIstioResource =
+            (IstioResource) client.customResources(customResourceDefinition, IstioResource.class, KubernetesResourceList.class, done)
+                .create(istioResource);
+
+        return createdIstioResource;
+    }
+}

--- a/istio-applier/src/main/java/me/snowdrop/istio/applier/ObjectMapperFactory.java
+++ b/istio-applier/src/main/java/me/snowdrop/istio/applier/ObjectMapperFactory.java
@@ -1,0 +1,11 @@
+package me.snowdrop.istio.applier;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLParser;
+
+public class ObjectMapperFactory {
+
+    public static ObjectMapper objectMapper = new ObjectMapper(new YAMLFactory());
+
+}

--- a/istio-applier/src/main/java/me/snowdrop/istio/applier/RouteRuleApplier.java
+++ b/istio-applier/src/main/java/me/snowdrop/istio/applier/RouteRuleApplier.java
@@ -1,0 +1,31 @@
+package me.snowdrop.istio.applier;
+
+import java.util.Map;
+import me.snowdrop.istio.api.model.IstioResource;
+import me.snowdrop.istio.api.model.v1.routing.DoneableRouteRule;
+import me.snowdrop.istio.api.model.v1.routing.RouteRule;
+
+public class RouteRuleApplier implements Applier {
+
+    private static final String ROUTE_RULE_KIND = "RouteRule";
+    static final String ROUTE_RULE_CUSTOM_RESOURCE_DEFINITION = "routerules.config.istio.io";
+
+    private final Adapter adapter;
+
+    public RouteRuleApplier(Adapter adapter) {
+        this.adapter = adapter;
+    }
+    
+    @Override
+    public boolean canApply(String kind) {
+        return ROUTE_RULE_KIND.equals(kind);
+    }
+
+    @Override
+    public IstioResource apply(Map<String, Object> resource) {
+
+        final RouteRule routeRule = ObjectMapperFactory.objectMapper.convertValue(resource, RouteRule.class);
+        return this.adapter.createCustomResource(ROUTE_RULE_CUSTOM_RESOURCE_DEFINITION, routeRule, DoneableRouteRule.class);
+
+    }
+}

--- a/istio-applier/src/test/java/me/snowdrop/istio/applier/IstioExecutorTest.java
+++ b/istio-applier/src/test/java/me/snowdrop/istio/applier/IstioExecutorTest.java
@@ -1,0 +1,93 @@
+package me.snowdrop.istio.applier;
+
+import java.io.InputStream;
+import java.util.Optional;
+import me.snowdrop.istio.api.model.IstioResource;
+import me.snowdrop.istio.api.model.v1.routing.DestinationPolicy;
+import me.snowdrop.istio.api.model.v1.routing.DoneableDestinationPolicy;
+import me.snowdrop.istio.api.model.v1.routing.DoneableEgressRule;
+import me.snowdrop.istio.api.model.v1.routing.DoneableRouteRule;
+import me.snowdrop.istio.api.model.v1.routing.EgressRule;
+import me.snowdrop.istio.api.model.v1.routing.RouteRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class IstioExecutorTest {
+
+    @Mock
+    Adapter adapter;
+
+    @Test
+    public void should_apply_route_rule_istio_resource() {
+
+        // Given
+        final IstioExecutor istioExecutor = new IstioExecutor(adapter);
+        final InputStream routeRule = Thread.currentThread().getContextClassLoader()
+            .getResourceAsStream("route-rule.yaml");
+
+        // When
+        when(adapter.createCustomResource(eq(RouteRuleApplier.ROUTE_RULE_CUSTOM_RESOURCE_DEFINITION), any(RouteRule.class),
+            eq(DoneableRouteRule.class))).thenReturn(new RouteRule());
+
+        // Then
+        final Optional<IstioResource> istioResource = istioExecutor.registerCustomResource(routeRule);
+
+        assertThat(istioResource).isPresent();
+        verify(adapter, times(1)).createCustomResource(eq(RouteRuleApplier.ROUTE_RULE_CUSTOM_RESOURCE_DEFINITION), any(RouteRule.class),
+            eq(DoneableRouteRule.class));
+
+    }
+
+    @Test
+    public void should_apply_destination_policy_istio_resource() {
+
+        // Given
+        final IstioExecutor istioExecutor = new IstioExecutor(adapter);
+        final InputStream routeRule = Thread.currentThread().getContextClassLoader()
+            .getResourceAsStream("destination-policy.yaml");
+
+        // When
+        when(adapter.createCustomResource(eq(DestinationPolicyApplier.DESTINATION_POLICY_CUSTOM_RESOURCE_DEFINITION), any(DestinationPolicy.class),
+            eq(DoneableDestinationPolicy.class))).thenReturn(new DestinationPolicy());
+
+        // Then
+        final Optional<IstioResource> istioResource = istioExecutor.registerCustomResource(routeRule);
+
+        assertThat(istioResource).isPresent();
+        verify(adapter, times(1)).createCustomResource(eq(DestinationPolicyApplier.DESTINATION_POLICY_CUSTOM_RESOURCE_DEFINITION), any(DestinationPolicy.class),
+            eq(DoneableDestinationPolicy.class));
+
+    }
+
+    @Test
+    public void should_apply_egress_rule_istio_resource() {
+
+        // Given
+        final IstioExecutor istioExecutor = new IstioExecutor(adapter);
+        final InputStream routeRule = Thread.currentThread().getContextClassLoader()
+            .getResourceAsStream("egress-rule.yaml");
+
+        // When
+        when(adapter.createCustomResource(eq(EgressRuleApplier.EGRESS_RULE_CUSTOM_RESOURCE_DEFINITION), any(EgressRule.class),
+            eq(DoneableEgressRule.class))).thenReturn(new EgressRule());
+
+        // Then
+        final Optional<IstioResource> istioResource = istioExecutor.registerCustomResource(routeRule);
+
+        assertThat(istioResource).isPresent();
+        verify(adapter, times(1)).createCustomResource(eq(EgressRuleApplier.EGRESS_RULE_CUSTOM_RESOURCE_DEFINITION), any(EgressRule.class),
+            eq(DoneableEgressRule.class));
+
+    }
+
+}

--- a/istio-applier/src/test/resources/destination-policy.yaml
+++ b/istio-applier/src/test/resources/destination-policy.yaml
@@ -1,0 +1,9 @@
+apiVersion: config.istio.io/v1beta1
+kind: DestinationPolicy
+metadata:
+  name: reviews-random
+spec:
+  destination:
+    name: reviews
+  loadBalancing:
+    name: RANDOM

--- a/istio-applier/src/test/resources/egress-rule.yaml
+++ b/istio-applier/src/test/resources/egress-rule.yaml
@@ -1,0 +1,11 @@
+kind: EgressRule
+metadata:
+  name: foo-egress-rule
+spec:
+  destination:
+    service: www.foo.com
+  ports:
+    - port: 80
+      protocol: http
+    - port: 443
+      protocol: https

--- a/istio-applier/src/test/resources/route-rule.yaml
+++ b/istio-applier/src/test/resources/route-rule.yaml
@@ -1,0 +1,12 @@
+apiVersion: config.istio.io/v1alpha2
+kind: RouteRule
+metadata:
+  name: reviews-default
+spec:
+  destination:
+    name: reviews
+  precedence: 1
+  route:
+  - labels:
+      version: v3
+    weight: 100

--- a/pom.xml
+++ b/pom.xml
@@ -161,6 +161,10 @@
     <jsonschema2pojo.version>0.5.1</jsonschema2pojo.version>
     <validation-api.version>2.0.0.Final</validation-api.version>
     <kubernetes-model.version>2.0.4</kubernetes-model.version>
+    <kubernetes-client.version>3.1.7</kubernetes-client.version>
+    <junit.version>4.12</junit.version>
+    <mockito.version>2.13.0</mockito.version>
+    <assertj.version>3.9.0</assertj.version>
     <sundrio.version>0.7.6</sundrio.version>
     <lombok.version>1.16.18</lombok.version>
   </properties>
@@ -168,6 +172,7 @@
   <modules>
     <module>istio-model-annotator</module>
     <module>istio-model</module>
+    <module>istio-applier</module>
   </modules>
 
   <dependencyManagement>
@@ -188,6 +193,19 @@
         <version>${kubernetes-model.version}</version>
       </dependency>
       <dependency>
+        <groupId>io.fabric8</groupId>
+        <artifactId>kubernetes-client</artifactId>
+        <version>${kubernetes-client.version}</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>io.fabric8</groupId>
+        <artifactId>kubernetes-openshift-uberjar</artifactId>
+        <version>${kubernetes-client.version}</version>
+        <scope>provided</scope>
+        <classifier>versioned</classifier>
+      </dependency>
+      <dependency>
         <groupId>io.sundr</groupId>
         <artifactId>builder-annotations</artifactId>
         <version>${sundrio.version}</version>
@@ -196,6 +214,24 @@
         <groupId>org.projectlombok</groupId>
         <artifactId>lombok</artifactId>
         <version>${lombok.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>${junit.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>${mockito.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.assertj</groupId>
+        <artifactId>assertj-core</artifactId>
+        <version>${assertj.version}</version>
+        <scope>test</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
I have created the first part of the PR which implies creating a class to apply istio resources to the cluster.

Currently, I have only implemented the RouteRoules but if we agree with everything I'll implement for the rest.

I'd like to discuss is the names of the classes (I am really bad naming classes) and the `Adapter` interface. I have created this interface for next reason: There are two different kubernetes client (the f8 kubernates client and the f8 kubernetes client uberjar versioned) so to give support to both possibilities I needed to create this abstraction. This also applies if someday we need to apply some specific operations for OpenShift client or other kubernetes client that are out there.