### PR TITLE
Adds method to unregister istio resources

### DIFF
--- a/istio-client/src/main/java/me/snowdrop/istio/client/Adapter.java
+++ b/istio-client/src/main/java/me/snowdrop/istio/client/Adapter.java
@@ -7,6 +7,7 @@ import me.snowdrop.istio.api.model.IstioResource;
 
 public interface Adapter {
     List<IstioResource> createCustomResources(IstioResource... resources);
+    Boolean deleteCustomResources(IstioResource resource);
 
     KubernetesClient getKubernetesClient();
 }

--- a/istio-client/src/main/java/me/snowdrop/istio/client/IstioClient.java
+++ b/istio-client/src/main/java/me/snowdrop/istio/client/IstioClient.java
@@ -76,6 +76,10 @@ public class IstioClient {
         return client.createCustomResources(resource).get(0);
     }
 
+    public Boolean unregisterCustomResource(final IstioResource istioResource) {
+        return client.deleteCustomResources(istioResource);
+    }
+
     private static String readSpecFileFromInputStream(InputStream inputStream) {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         byte[] buffer = new byte[1024];


### PR DESCRIPTION
Notice that method receives one `IstioResource` instead of a list. I have done in this way because it is important to get the result of the operation (if it has been deleted or not) hence it returns a booelan (this is how the Kuberentes-Client does). The problem is that if I set as a list then I need to return a `Map<IstioResource, Boolean>` with each of the result, and then the caller needs to check this map to see if there is any false. So instead of complicating things in that way I prefer to just user can set one `IstioResource` and if it has more than one to delete just do a foreach