### PR TITLE
0.8.1

### DIFF
--- a/istio-client-uberjar/pom.xml
+++ b/istio-client-uberjar/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>istio-java-api</artifactId>
     <groupId>me.snowdrop</groupId>
-    <version>0.8</version>
+    <version>0.8.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/istio-client-uberjar/pom.xml
+++ b/istio-client-uberjar/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>istio-java-api</artifactId>
     <groupId>me.snowdrop</groupId>
-    <version>0.8-SNAPSHOT</version>
+    <version>0.8</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/istio-client/pom.xml
+++ b/istio-client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>me.snowdrop</groupId>
     <artifactId>istio-java-api</artifactId>
-    <version>0.8-SNAPSHOT</version>
+    <version>0.8</version>
   </parent>
 
   <artifactId>istio-client</artifactId>

--- a/istio-client/pom.xml
+++ b/istio-client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>me.snowdrop</groupId>
     <artifactId>istio-java-api</artifactId>
-    <version>0.8</version>
+    <version>0.8.1</version>
   </parent>
 
   <artifactId>istio-client</artifactId>

--- a/istio-client/src/main/java/me/snowdrop/istio/client/IstioClientFactory.java
+++ b/istio-client/src/main/java/me/snowdrop/istio/client/IstioClientFactory.java
@@ -15,7 +15,7 @@ import io.fabric8.kubernetes.client.KubernetesClient;
  */
 public class IstioClientFactory {
     public static IstioClient defaultClient(Config config) {
-        KubernetesClient client = new DefaultKubernetesClient(config);
+        KubernetesClient client = new KubernetesIstioClient(config);
 
         KubernetesAdapter adapter = new KubernetesAdapter(client);
         return new IstioClient(adapter);

--- a/istio-client/src/main/java/me/snowdrop/istio/client/IstioCustomResourceOperationsImpl.java
+++ b/istio-client/src/main/java/me/snowdrop/istio/client/IstioCustomResourceOperationsImpl.java
@@ -1,0 +1,106 @@
+package me.snowdrop.istio.client;
+
+import io.fabric8.kubernetes.api.builder.Function;
+import io.fabric8.kubernetes.api.model.Doneable;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+import io.fabric8.kubernetes.api.model.KubernetesResourceList;
+import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinition;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.dsl.base.HasMetadataOperation;
+import io.fabric8.kubernetes.client.dsl.internal.CustomResourceOperationsImpl;
+import io.fabric8.kubernetes.client.utils.Utils;
+import io.fabric8.kubernetes.internal.KubernetesDeserializer;
+import okhttp3.OkHttpClient;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+public class IstioCustomResourceOperationsImpl<T extends HasMetadata, L extends KubernetesResourceList, D extends Doneable<T>> extends CustomResourceOperationsImpl<T, L, D> {
+
+    public IstioCustomResourceOperationsImpl(OkHttpClient httpClient, Config configuration, CustomResourceDefinition crd, Class<T> resourceType, Class<L> resourceListType, Class<D> doneType) {
+        super(httpClient, configuration, apiGroup(crd), apiVersion(crd), resourceT(crd), (String)null, (String)null, false, (T)null, (String)null, false, resourceType, resourceListType, doneType);
+    }
+
+    public IstioCustomResourceOperationsImpl(OkHttpClient client, Config config, String apiGroup, String apiVersion, String resourceT, String namespace, String name, Boolean cascading, T item, String resourceVersion, Boolean reloadingFromServer, Class<T> type, Class<L> listType, Class<D> doneableType) {
+        super(client, config, apiGroup, apiVersion, resourceT, namespace, name, cascading, item, resourceVersion, reloadingFromServer, type, listType, doneableType);
+
+    }
+
+    @Override
+    public IstioCustomResourceOperationsImpl inNamespace(String namespace) {
+
+        return new IstioCustomResourceOperationsImpl(client, getConfig(), getAPIGroup(), getAPIVersion(), getResourceT(), namespace, getName(), isCascading(), getItem(), getResourceVersion(), isReloadingFromServer(), getType(), getListType(), getDoneableType());
+
+    }
+
+    @Override
+    public IstioCustomResourceOperationsImpl withName(String name) {
+        return new IstioCustomResourceOperationsImpl(client, getConfig(), getAPIGroup(), getAPIVersion(), getResourceT(), getNamespace(), name, isCascading(), getItem(), getResourceVersion(), isReloadingFromServer(), getType(), getListType(), getDoneableType());
+    }
+
+    @Override
+    public T replace(T item) {
+            String fixedResourceVersion = this.getResourceVersion();
+            Exception caught = null;
+            int maxTries = 10;
+
+            for(int i = 0; i < maxTries; ++i) {
+                try {
+                    if (this.isCascading() && this.reaper != null && !this.isReaping()) {
+                        this.setReaping(true);
+                        this.reaper.reap();
+                    }
+
+                    final String resourceVersion;
+                    if (fixedResourceVersion != null) {
+                        resourceVersion = fixedResourceVersion;
+                    } else {
+                        T got = (T)this.get();
+                        if (got == null) {
+                            return null;
+                        }
+
+                        if (got.getMetadata() != null) {
+                            resourceVersion = got.getMetadata().getResourceVersion();
+                        } else {
+                            resourceVersion = null;
+                        }
+                    }
+
+                    me.snowdrop.istio.api.builder.Function<T, T> visitor = new me.snowdrop.istio.api.builder.Function<T, T>() {
+                        public T apply(T resource) {
+                            try {
+                                resource.getMetadata().setResourceVersion(resourceVersion);
+                                return (T)IstioCustomResourceOperationsImpl.this.handleReplace(resource);
+                            } catch (Exception var3) {
+                                throw KubernetesClientException.launderThrowable(IstioCustomResourceOperationsImpl.this.forOperationType("replace"), var3);
+                            }
+                        }
+                    };
+                    D doneable = this.getDoneableType().getDeclaredConstructor(this.getType(), me.snowdrop.istio.api.builder.Function.class).newInstance(item, visitor);
+                    return (T)doneable.done();
+                } catch (KubernetesClientException var10) {
+                    caught = var10;
+                    if (var10.getCode() != 409 || fixedResourceVersion != null) {
+                        throw KubernetesClientException.launderThrowable(this.forOperationType("replace"), (Throwable)caught);
+                    }
+
+                    if (i < maxTries - 1) {
+                        try {
+                            TimeUnit.SECONDS.sleep(1L);
+                        } catch (InterruptedException var9) {
+                            ;
+                        }
+                    }
+                } catch (Exception var11) {
+                    caught = var11;
+                }
+            }
+
+            throw KubernetesClientException.launderThrowable(this.forOperationType("replace"), (Throwable)caught);
+    }
+}

--- a/istio-client/src/main/java/me/snowdrop/istio/client/KubernetesAdapter.java
+++ b/istio-client/src/main/java/me/snowdrop/istio/client/KubernetesAdapter.java
@@ -27,7 +27,7 @@ public class KubernetesAdapter implements Adapter {
 
                 final IstioResource result = client.customResources(customResourceDefinition, IstioResource.class, KubernetesResourceList.class, DoneableIstioResource.class)
                         .inNamespace(client.getNamespace())
-                        .create(resource);
+                        .createOrReplace(resource);
                 results.add(result);
             }
 

--- a/istio-client/src/main/java/me/snowdrop/istio/client/KubernetesIstioClient.java
+++ b/istio-client/src/main/java/me/snowdrop/istio/client/KubernetesIstioClient.java
@@ -1,0 +1,26 @@
+package me.snowdrop.istio.client;
+
+import io.fabric8.kubernetes.api.model.Doneable;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.KubernetesResourceList;
+import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinition;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.dsl.internal.CustomResourceOperationsImpl;
+
+public class KubernetesIstioClient extends DefaultKubernetesClient {
+
+    public KubernetesIstioClient(Config config) throws KubernetesClientException {
+        super(config);
+    }
+
+    @Override
+    public <T extends HasMetadata, L extends KubernetesResourceList, D extends Doneable<T>> MixedOperation<T, L, D, Resource<T, D>> customResources(CustomResourceDefinition crd, Class<T> resourceType, Class<L> listClass, Class<D> doneClass) {
+        return new IstioCustomResourceOperationsImpl(this.httpClient, this.getConfiguration(), crd, resourceType, listClass, doneClass);
+    }
+
+}
+

--- a/istio-common/pom.xml
+++ b/istio-common/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>istio-java-api</artifactId>
     <groupId>me.snowdrop</groupId>
-    <version>0.8</version>
+    <version>0.8.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/istio-common/pom.xml
+++ b/istio-common/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>istio-java-api</artifactId>
     <groupId>me.snowdrop</groupId>
-    <version>0.8-SNAPSHOT</version>
+    <version>0.8</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/istio-model-annotator/pom.xml
+++ b/istio-model-annotator/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>me.snowdrop</groupId>
         <artifactId>istio-java-api</artifactId>
-        <version>0.8</version>
+        <version>0.8.1</version>
     </parent>
 
     <name>Snowdrop :: Istio Java API :: Model Annotator</name>
     <artifactId>istio-model-annotator</artifactId>
-    <version>0.8</version>
+    <version>0.8.1</version>
 
     <dependencies>
         <dependency>

--- a/istio-model-annotator/pom.xml
+++ b/istio-model-annotator/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>me.snowdrop</groupId>
         <artifactId>istio-java-api</artifactId>
-        <version>0.8-SNAPSHOT</version>
+        <version>0.8</version>
     </parent>
 
     <name>Snowdrop :: Istio Java API :: Model Annotator</name>
     <artifactId>istio-model-annotator</artifactId>
-    <version>0.8-SNAPSHOT</version>
+    <version>0.8</version>
 
     <dependencies>
         <dependency>

--- a/istio-model/pom.xml
+++ b/istio-model/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>me.snowdrop</groupId>
     <artifactId>istio-java-api</artifactId>
-    <version>0.8</version>
+    <version>0.8.1</version>
   </parent>
 
   <artifactId>istio-model</artifactId>

--- a/istio-model/pom.xml
+++ b/istio-model/pom.xml
@@ -16,14 +16,13 @@
     limitations under the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>me.snowdrop</groupId>
     <artifactId>istio-java-api</artifactId>
-    <version>0.8-SNAPSHOT</version>
+    <version>0.8</version>
   </parent>
 
   <artifactId>istio-model</artifactId>
@@ -157,8 +156,8 @@
             <configuration>
               <target>
                 <echo>removing the duplicate / useless generated classes</echo>
-                <delete file="${basedir}/target/generated-sources/me/snowdrop/istio/api/model/Duration.java" verbose="true"/>
-                <delete file="${basedir}/target/generated-sources/me/snowdrop/istio/api/model/IstioSchema.java" verbose="true"/>
+                <delete file="${basedir}/target/generated-sources/me/snowdrop/istio/api/model/Duration.java" verbose="true" />
+                <delete file="${basedir}/target/generated-sources/me/snowdrop/istio/api/model/IstioSchema.java" verbose="true" />
               </target>
             </configuration>
             <goals>
@@ -172,8 +171,8 @@
               <target>
                 <echo>removing duplicated builder classes</echo>
                 <delete verbose="true">
-                  <fileset dir="${basedir}/target/generated-sources/annotations/io"/>
-                  <fileset dir="${basedir}/target/classes/io"/>
+                  <fileset dir="${basedir}/target/generated-sources/annotations/io" />
+                  <fileset dir="${basedir}/target/classes/io" />
                 </delete>
               </target>
             </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>me.snowdrop</groupId>
   <artifactId>istio-java-api</artifactId>
-  <version>0.8</version>
+  <version>0.8.1</version>
   <packaging>pom</packaging>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>me.snowdrop</groupId>
   <artifactId>istio-java-api</artifactId>
-  <version>0.8-SNAPSHOT</version>
+  <version>0.8</version>
   <packaging>pom</packaging>
 
 
@@ -62,7 +62,7 @@
     <url>https://github.com/snowdrop/istio-java-api</url>
     <connection>scm:git:https://github.com/snowdrop/istio-java-api.git</connection>
     <developerConnection>scm:git:git@github.com:snowdrop/istio-java-api.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>0.8</tag>
   </scm>
 
 


### PR DESCRIPTION
We tried to allow for creating or replacing istio custom resources (instead of just creating).
The change works but it's probably not the best way to achieve this result. A better way would be to just use the standard Function class from the kubernetes client in DoneableIstioResource instead of the generated one ( that should work, although I have been unable to test it).
Please let us know if you have any suggestion on how to achieve this result or if you think this change is fine as it is.