### PR TITLE
Change builder name to make replace work

### DIFF
--- a/istio-client/src/main/java/me/snowdrop/istio/client/Adapter.java
+++ b/istio-client/src/main/java/me/snowdrop/istio/client/Adapter.java
@@ -7,6 +7,7 @@ import me.snowdrop.istio.api.model.IstioResource;
 
 public interface Adapter {
     List<IstioResource> createCustomResources(IstioResource... resources);
+    List<IstioResource> createOrReplaceCustomResources(IstioResource... resources);
     Boolean deleteCustomResources(IstioResource resource);
 
     KubernetesClient getKubernetesClient();

--- a/istio-client/src/main/java/me/snowdrop/istio/client/IstioClient.java
+++ b/istio-client/src/main/java/me/snowdrop/istio/client/IstioClient.java
@@ -72,8 +72,13 @@ public class IstioClient {
         return registerCustomResources(readSpecFileFromInputStream(resource));
     }
 
+
     public IstioResource registerCustomResource(final IstioResource resource) {
         return client.createCustomResources(resource).get(0);
+    }
+
+    public IstioResource registerOrUpdateCustomResource(final IstioResource resource) {
+        return client.createOrReplaceCustomResources(resource).get(0);
     }
 
     public Boolean unregisterCustomResource(final IstioResource istioResource) {

--- a/istio-client/src/main/java/me/snowdrop/istio/client/KubernetesAdapter.java
+++ b/istio-client/src/main/java/me/snowdrop/istio/client/KubernetesAdapter.java
@@ -37,6 +37,25 @@ public class KubernetesAdapter implements Adapter {
         return Collections.emptyList();
     }
 
+    public List<IstioResource> createOrReplaceCustomResources(IstioResource... resources) {
+        if(resources != null) {
+            List<IstioResource> results = new ArrayList<>(resources.length);
+
+            for (IstioResource resource : resources) {
+                final CustomResourceDefinition customResourceDefinition = getCustomResourceDefinition(resource);
+
+                final IstioResource result = client.customResources(customResourceDefinition, IstioResource.class, KubernetesResourceList.class, DoneableIstioResource.class)
+                        .inNamespace(client.getNamespace())
+                        .createOrReplace(resource);
+                results.add(result);
+            }
+
+            return results;
+        }
+
+        return Collections.emptyList();
+    }
+
     public Boolean deleteCustomResources(IstioResource resource) {
 
         if (resource != null) {

--- a/istio-model-annotator/src/main/java/me/snowdrop/istio/annotator/IstioTypeAnnotator.java
+++ b/istio-model-annotator/src/main/java/me/snowdrop/istio/annotator/IstioTypeAnnotator.java
@@ -29,7 +29,7 @@ import org.jsonschema2pojo.Jackson2Annotator;
  */
 public class IstioTypeAnnotator extends Jackson2Annotator {
 
-    private static final String BUILDER_PACKAGE = "me.snowdrop.istio.api.builder";
+    private static final String BUILDER_PACKAGE = "io.fabric8.kubernetes.api.builder";
 
     public IstioTypeAnnotator(GenerationConfig generationConfig) {
         super(generationConfig);

--- a/istio-model/src/main/java/me/snowdrop/istio/api/model/Duration.java
+++ b/istio-model/src/main/java/me/snowdrop/istio/api/model/Duration.java
@@ -61,7 +61,7 @@ public class Duration implements Serializable {
     public Duration() {
     }
 
-    @Buildable(generateBuilderPackage = true, builderPackage = "me.snowdrop.istio.api.builder", editableEnabled = false, validationEnabled = true)
+    @Buildable(generateBuilderPackage = true, builderPackage = "io.fabric8.kubernetes.api.builder", editableEnabled = false, validationEnabled = true)
     public Duration(Integer nanos, Long seconds) {
         this.nanos = nanos;
         this.seconds = seconds;

--- a/istio-model/src/main/java/me/snowdrop/istio/api/model/IstioBaseSpec.java
+++ b/istio-model/src/main/java/me/snowdrop/istio/api/model/IstioBaseSpec.java
@@ -18,7 +18,7 @@ import lombok.ToString;
  */
 @ToString
 @EqualsAndHashCode
-@Buildable(editableEnabled = false, validationEnabled = true, generateBuilderPackage = true, builderPackage = "me.snowdrop.istio.api.builder", inline = @Inline(type = Doneable.class, prefix = "Doneable", value = "done"))
+@Buildable(editableEnabled = false, validationEnabled = true, generateBuilderPackage = true, builderPackage = "io.fabric8.kubernetes.api.builder", inline = @Inline(type = Doneable.class, prefix = "Doneable", value = "done"))
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class IstioBaseSpec implements IstioSpec {
 }

--- a/istio-model/src/main/java/me/snowdrop/istio/api/model/IstioResource.java
+++ b/istio-model/src/main/java/me/snowdrop/istio/api/model/IstioResource.java
@@ -33,7 +33,7 @@ import me.snowdrop.istio.api.internal.IstioDeserializer;
 })
 @ToString
 @EqualsAndHashCode
-@Buildable(builderPackage = "me.snowdrop.istio.api.builder", generateBuilderPackage = true, editableEnabled = false, refs = {@BuildableReference(ObjectMeta.class)}, inline = @Inline(type = Doneable.class, prefix = "Doneable", value = "done"))
+@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder", generateBuilderPackage = true, editableEnabled = false, refs = {@BuildableReference(ObjectMeta.class)}, inline = @Inline(type = Doneable.class, prefix = "Doneable", value = "done"))
 @JsonDeserialize(using = IstioDeserializer.class)
 public class IstioResource implements HasMetadata, Serializable {
     private ObjectMeta metadata;

--- a/istio-model/src/main/java/me/snowdrop/istio/api/model/v1/cexl/TypedValue.java
+++ b/istio-model/src/main/java/me/snowdrop/istio/api/model/v1/cexl/TypedValue.java
@@ -32,7 +32,7 @@ import org.antlr.v4.runtime.tree.ParseTreeWalker;
 /**
  * @author <a href="claprun@redhat.com">Christophe Laprun</a>
  */
-@Buildable(builderPackage = "me.snowdrop.istio.api.builder", generateBuilderPackage = true, editableEnabled = false)
+@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder", generateBuilderPackage = true, editableEnabled = false)
 @EqualsAndHashCode
 @ToString
 @JsonSerialize(using = TypedValue.TypedValueSerializer.class)

--- a/istio-model/src/main/java/me/snowdrop/istio/api/model/v1/mixer/template/CheckNothing.java
+++ b/istio-model/src/main/java/me/snowdrop/istio/api/model/v1/mixer/template/CheckNothing.java
@@ -20,7 +20,7 @@ import me.snowdrop.istio.api.model.IstioBaseSpec;
 @JsonDeserialize
 @ToString
 @EqualsAndHashCode
-@Buildable(editableEnabled = false, validationEnabled = true, generateBuilderPackage = true, builderPackage = "me.snowdrop.istio.api.builder", inline = @Inline(type = Doneable.class, prefix = "Doneable", value = "done"))
+@Buildable(editableEnabled = false, validationEnabled = true, generateBuilderPackage = true, builderPackage = "io.fabric8.kubernetes.api.builder", inline = @Inline(type = Doneable.class, prefix = "Doneable", value = "done"))
 public class CheckNothing extends IstioBaseSpec {
     @Override
     public String getKind() {

--- a/istio-model/src/main/java/me/snowdrop/istio/api/model/v1/mixer/template/ListEntry.java
+++ b/istio-model/src/main/java/me/snowdrop/istio/api/model/v1/mixer/template/ListEntry.java
@@ -22,7 +22,7 @@ import me.snowdrop.istio.api.model.IstioBaseSpec;
 @JsonDeserialize
 @ToString
 @EqualsAndHashCode
-@Buildable(editableEnabled = false, validationEnabled = true, generateBuilderPackage = true, builderPackage = "me.snowdrop.istio.api.builder", inline = @Inline(type = Doneable.class, prefix = "Doneable", value = "done"))
+@Buildable(editableEnabled = false, validationEnabled = true, generateBuilderPackage = true, builderPackage = "io.fabric8.kubernetes.api.builder", inline = @Inline(type = Doneable.class, prefix = "Doneable", value = "done"))
 public class ListEntry extends IstioBaseSpec {
     private String value;
 

--- a/istio-model/src/main/java/me/snowdrop/istio/api/model/v1/mixer/template/LogEntry.java
+++ b/istio-model/src/main/java/me/snowdrop/istio/api/model/v1/mixer/template/LogEntry.java
@@ -27,7 +27,7 @@ import me.snowdrop.istio.api.model.v1.cexl.TypedValue;
 @JsonDeserialize
 @ToString
 @EqualsAndHashCode
-@Buildable(editableEnabled = false, validationEnabled = true, generateBuilderPackage = true, builderPackage = "me.snowdrop.istio.api.builder", inline = @Inline(type = Doneable.class, prefix = "Doneable", value = "done"))
+@Buildable(editableEnabled = false, validationEnabled = true, generateBuilderPackage = true, builderPackage = "io.fabric8.kubernetes.api.builder", inline = @Inline(type = Doneable.class, prefix = "Doneable", value = "done"))
 public class LogEntry extends IstioBaseSpec {
     /*
     apiVersion: "config.istio.io/v1alpha2"

--- a/istio-model/src/main/java/me/snowdrop/istio/api/model/v1/mixer/template/Metric.java
+++ b/istio-model/src/main/java/me/snowdrop/istio/api/model/v1/mixer/template/Metric.java
@@ -26,7 +26,7 @@ import me.snowdrop.istio.api.model.v1.cexl.TypedValue;
 @JsonDeserialize
 @ToString
 @EqualsAndHashCode
-@Buildable(editableEnabled = false, validationEnabled = true, generateBuilderPackage = true, builderPackage = "me.snowdrop.istio.api.builder", inline = @Inline(type = Doneable.class, prefix = "Doneable", value = "done"))
+@Buildable(editableEnabled = false, validationEnabled = true, generateBuilderPackage = true, builderPackage = "io.fabric8.kubernetes.api.builder", inline = @Inline(type = Doneable.class, prefix = "Doneable", value = "done"))
 public class Metric extends IstioBaseSpec {
     /**
      * The value being reported.

--- a/istio-model/src/main/java/me/snowdrop/istio/api/model/v1/mixer/template/Quota.java
+++ b/istio-model/src/main/java/me/snowdrop/istio/api/model/v1/mixer/template/Quota.java
@@ -26,7 +26,7 @@ import me.snowdrop.istio.api.model.v1.cexl.TypedValue;
 @JsonDeserialize
 @ToString
 @EqualsAndHashCode
-@Buildable(editableEnabled = false, validationEnabled = true, generateBuilderPackage = true, builderPackage = "me.snowdrop.istio.api.builder", inline = @Inline(type = Doneable.class, prefix = "Doneable", value = "done"))
+@Buildable(editableEnabled = false, validationEnabled = true, generateBuilderPackage = true, builderPackage = "io.fabric8.kubernetes.api.builder", inline = @Inline(type = Doneable.class, prefix = "Doneable", value = "done"))
 public class Quota extends IstioBaseSpec {
     @JsonDeserialize(using = TypedValueMapDeserializer.class)
     private Map<String, TypedValue> dimensions;

--- a/istio-model/src/main/java/me/snowdrop/istio/api/model/v1/mixer/template/ReportNothing.java
+++ b/istio-model/src/main/java/me/snowdrop/istio/api/model/v1/mixer/template/ReportNothing.java
@@ -20,7 +20,7 @@ import me.snowdrop.istio.api.model.IstioBaseSpec;
 @JsonDeserialize
 @ToString
 @EqualsAndHashCode
-@Buildable(editableEnabled = false, validationEnabled = true, generateBuilderPackage = true, builderPackage = "me.snowdrop.istio.api.builder", inline = @Inline(type = Doneable.class, prefix = "Doneable", value = "done"))
+@Buildable(editableEnabled = false, validationEnabled = true, generateBuilderPackage = true, builderPackage = "io.fabric8.kubernetes.api.builder", inline = @Inline(type = Doneable.class, prefix = "Doneable", value = "done"))
 public class ReportNothing extends IstioBaseSpec {
     @Override
     public String getKind() {


### PR DESCRIPTION
Use io.fabric8.kubernetes.api.builder instead of me.snowdrop.istio.api.builder

Our issue was that when we want to do a replace or update operation on custom istio resource, it was failing with the error that it can not find the constructor.
We tried a few solutions and this is the cleanest solution we have.

We can fix the naming of methods if you recommend something else. 