### PR TITLE
Add Json Deserializer for PortSelector

### DIFF
--- a/istio-model/pom.xml
+++ b/istio-model/pom.xml
@@ -168,6 +168,8 @@
                 <delete file="${basedir}/target/generated-sources/me/snowdrop/istio/api/model/v1/cexl/TypedValue.java" verbose="true" />
                 <delete file="${basedir}/target/generated-sources/me/snowdrop/istio/api/model/v1/networking/StringMatch.java"
                         verbose="true"/>
+                <delete file="${basedir}/target/generated-sources/me/snowdrop/istio/api/model/v1/networking/PortSelector.java"
+                        verbose="true"/>
               </target>
             </configuration>
             <goals>

--- a/istio-model/src/main/java/me/snowdrop/istio/api/internal/PortSelectorDeserializer.java
+++ b/istio-model/src/main/java/me/snowdrop/istio/api/internal/PortSelectorDeserializer.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ * <p>
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package me.snowdrop.istio.api.internal;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import me.snowdrop.istio.api.model.v1.networking.*;
+
+import java.io.IOException;
+import java.util.Map;
+
+public class PortSelectorDeserializer extends JsonDeserializer<PortSelector> {
+    @Override
+    public PortSelector deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException, JsonProcessingException {
+        ObjectNode node = jsonParser.readValueAsTree();
+
+        // there should be exactly one field
+        final Map.Entry<String, JsonNode> field = node.fields().next();
+        final int value = field.getValue().asInt();
+        return new PortSelector(value);
+    }
+}

--- a/istio-model/src/main/java/me/snowdrop/istio/api/model/v1/networking/PortSelector.java
+++ b/istio-model/src/main/java/me/snowdrop/istio/api/model/v1/networking/PortSelector.java
@@ -1,0 +1,62 @@
+package me.snowdrop.istio.api.model.v1.networking;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.validation.Valid;
+
+import com.fasterxml.jackson.annotation.*;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.fabric8.kubernetes.api.model.Doneable;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.Inline;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import me.snowdrop.istio.api.internal.PortSelectorDeserializer;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonDeserialize(using = PortSelectorDeserializer.class)
+@ToString
+@EqualsAndHashCode
+@Buildable(editableEnabled = false, validationEnabled = true, generateBuilderPackage = true, builderPackage = "io.fabric8.kubernetes.api.builder", inline = @Inline(type = Doneable.class, prefix = "Doneable", value = "done"))
+public class PortSelector implements Serializable {
+
+    @JsonIgnore
+    @Valid
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    private final static long serialVersionUID = -1242311127347026943L;
+
+    @JsonProperty
+    private Integer number;
+
+    /**
+     * No args constructor for use in serialization
+     */
+    public PortSelector() {
+    }
+
+    public PortSelector(Integer number) {
+        this.number = number;
+    }
+
+    public Integer getNumber() {
+        return number;
+    }
+
+    public void setNumber(Integer number) {
+        this.number = number;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+}

--- a/istio-model/src/main/resources/schema/istio-schema.json
+++ b/istio-model/src/main/resources/schema/istio-schema.json
@@ -115,7 +115,7 @@
             "$ref": "#/definitions/istio_adapter_dogstatsd_Params_MetricInfo",
             "javaType": "me.snowdrop.istio.adapter.dogstatsd.MetricInfo"
           },
-          "javaType": "java.util.Map\u003cString,MetricInfo\u003e"
+          "javaType": "java.util.Map\u003cString,me.snowdrop.istio.adapter.dogstatsd.MetricInfo\u003e"
         },
         "prefix": {
           "type": "string",
@@ -355,7 +355,7 @@
             "$ref": "#/definitions/istio_adapter_solarwinds_Params_LogInfo",
             "javaType": "me.snowdrop.istio.adapter.solarwinds.LogInfo"
           },
-          "javaType": "java.util.Map\u003cString,LogInfo\u003e"
+          "javaType": "java.util.Map\u003cString,me.snowdrop.istio.adapter.solarwinds.LogInfo\u003e"
         },
         "metrics": {
           "type": "object",
@@ -364,7 +364,7 @@
             "$ref": "#/definitions/istio_adapter_solarwinds_Params_MetricInfo",
             "javaType": "me.snowdrop.istio.adapter.solarwinds.MetricInfo"
           },
-          "javaType": "java.util.Map\u003cString,MetricInfo\u003e"
+          "javaType": "java.util.Map\u003cString,me.snowdrop.istio.adapter.solarwinds.MetricInfo\u003e"
         },
         "papertrailLocalRetentionDuration": {
           "type": "integer",
@@ -606,7 +606,7 @@
             "$ref": "#/definitions/istio_mixer_Attributes_AttributeValue",
             "javaType": "me.snowdrop.istio.api.model.v1.mixer.AttributeValue"
           },
-          "javaType": "java.util.Map\u003cString,AttributeValue\u003e"
+          "javaType": "java.util.Map\u003cString,me.snowdrop.istio.api.model.v1.mixer.AttributeValue\u003e"
         }
       },
       "additionalProperties": true,

--- a/pkg/schemagen/generate.go
+++ b/pkg/schemagen/generate.go
@@ -241,6 +241,8 @@ func (g *schemaGenerator) javaType(t reflect.Type) string {
 				return "me.snowdrop.istio.api.model.v1.cexl.TypedValue"
 			case "StringMatch":
 				return "me.snowdrop.istio.api.model.v1.networking.StringMatch"
+			case "PortSelector":
+                return "me.snowdrop.istio.api.model.v1.networking.PortSelector"
 			default:
 				if len(name) == 0 && t.NumField() == 0 {
 					return "Object"


### PR DESCRIPTION
I saw your fix for StringMatch and I decided same deserialiser can be used for PortSelector.
Although Port selector can be "name" or "number" in protobuf definition, only number is documented.
I think only number is supported as well. 