### PR TITLE
Fix handling of plurals

### DIFF
--- a/istio-client/src/main/resources/resource-operation.vm
+++ b/istio-client/src/main/resources/resource-operation.vm
@@ -37,6 +37,8 @@ import java.util.TreeMap;
 #set ($version = $annotation.getParameters().get("value"))
 #set ($apiGroup = $version.split("/")[0])
 #set ($apiVersion = $version.split("/")[1])
+#elseif ($annotation.getClassRef().getName().equals("IstioKind"))
+#set ($plural = $annotation.getParameters().get("plural"))
 #end
 #end
 
@@ -47,14 +49,14 @@ public class ${model.name}OperationImpl extends HasMetadataOperation<${model.nam
   }
 
   public ${model.name}OperationImpl(OkHttpClient client, Config config, String apiVersion, String namespace, String name, Boolean cascading, ${model.name} item, String resourceVersion, Boolean reloadingFromServer, long gracePeriodSeconds, Map<String, String> labels, Map<String, String> labelsNot, Map<String, String[]> labelsIn, Map<String, String[]> labelsNotIn, Map<String, String> fields) {
-    super(client, config, "$apiGroup", apiVersion, "${model.name.toLowerCase()}s", namespace, name, cascading, item, resourceVersion, reloadingFromServer, gracePeriodSeconds, labels, labelsNot, labelsIn, labelsNotIn, fields);
+    super(client, config, "$apiGroup", apiVersion, "$plural", namespace, name, cascading, item, resourceVersion, reloadingFromServer, gracePeriodSeconds, labels, labelsNot, labelsIn, labelsNotIn, fields);
   }
 
   public ${model.name}OperationImpl(OkHttpClient client, Config config, String apiGroup, String apiVersion, String namespace, String name, Boolean cascading, ${model.name} item, String resourceVersion, Boolean reloadingFromServer, long gracePeriodSeconds, Map<String, String> labels, Map<String, String> labelsNot, Map<String, String[]> labelsIn, Map<String, String[]> labelsNotIn, Map<String, String> fields) {
-    super(client, config, apiGroup, apiVersion, "${model.name.toLowerCase()}s", namespace, name, cascading, item, resourceVersion, reloadingFromServer, gracePeriodSeconds, labels, labelsNot, labelsIn, labelsNotIn, fields);
+    super(client, config, apiGroup, apiVersion, "$plural", namespace, name, cascading, item, resourceVersion, reloadingFromServer, gracePeriodSeconds, labels, labelsNot, labelsIn, labelsNotIn, fields);
   }
 
-@Override
+  @Override
   public NonNamespaceOperation<${model.name}, ${model.name}List, Doneable${model.name}, Resource<${model.name}, Doneable${model.name}>> inNamespace(String namespace) {
     return new ${model.name}OperationImpl(client, config, apiGroup, apiVersion, namespace, name, isCascading(), getItem(), getResourceVersion(), isReloadingFromServer(), getGracePeriodSeconds(), getLabels(), getLabelsNot(), getLabelsIn(), getLabelsNotIn(), getFields());
   }

--- a/istio-client/src/test/java/me/snowdrop/istio/client/it/PolicyIT.java
+++ b/istio-client/src/test/java/me/snowdrop/istio/client/it/PolicyIT.java
@@ -1,0 +1,72 @@
+package me.snowdrop.istio.client.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import me.snowdrop.istio.api.authentication.v1alpha1.Policy;
+import me.snowdrop.istio.api.authentication.v1alpha1.PolicyBuilder;
+import me.snowdrop.istio.api.authentication.v1alpha1.PolicySpec;
+import me.snowdrop.istio.api.authentication.v1alpha1.TargetSelectorBuilder;
+import me.snowdrop.istio.clientv2.DefaultIstioClient;
+import me.snowdrop.istio.clientv2.IstioClient;
+import org.junit.Test;
+
+public class PolicyIT {
+
+    private final IstioClient istioClient = new DefaultIstioClient();
+
+    /*
+    apiVersion: authentication.istio.io/v1alpha1
+    kind: Policy
+    metadata:
+      name: basic-policy
+    spec:
+      targets:
+      - name: service-a
+     */
+    @Test
+    public void checkBasicPolicy() {
+        //given
+        final Policy policy = new PolicyBuilder()
+                .withApiVersion("authentication.istio.io/v1alpha1")
+                .withNewMetadata()
+                .withName("basic-policy")
+                .endMetadata()
+                .withNewSpec()
+                .addToTargets(new TargetSelectorBuilder().withName("service-a").build())
+                .endSpec()
+                .build();
+
+        //when
+        final Policy resultResource = istioClient.policy().create(policy);
+
+        //then
+        assertThat(resultResource).isNotNull().satisfies(istioResource -> {
+
+            assertThat(istioResource.getKind()).isEqualTo("Policy");
+
+            assertThat(istioResource)
+                    .extracting("metadata")
+                    .extracting("name")
+                    .containsOnly("basic-policy");
+        });
+
+        //and
+        final PolicySpec resultSpec = resultResource.getSpec();
+
+        //and
+        assertThat(resultSpec).satisfies(ps -> {
+
+            assertThat(ps.getTargets()).hasSize(1);
+            assertThat(ps.getTargets().get(0)).satisfies(ts ->
+                assertThat(ts.getName()).isEqualTo("service-a")
+            );
+        });
+
+        //when
+        final Boolean deleteResult = istioClient.policy().delete(resultResource);
+
+        //then
+        assertThat(deleteResult).isTrue();
+    }
+
+}

--- a/istio-common/src/main/java/me/snowdrop/istio/api/internal/IstioKind.java
+++ b/istio-common/src/main/java/me/snowdrop/istio/api/internal/IstioKind.java
@@ -18,4 +18,5 @@ import java.lang.annotation.Target;
 @Target(ElementType.TYPE)
 public @interface IstioKind {
     String name();
+    String plural();
 }

--- a/istio-common/src/main/java/me/snowdrop/istio/api/internal/IstioSpecRegistry.java
+++ b/istio-common/src/main/java/me/snowdrop/istio/api/internal/IstioSpecRegistry.java
@@ -14,7 +14,6 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
-
 import me.snowdrop.istio.api.IstioSpec;
 
 /**
@@ -147,6 +146,15 @@ public class IstioSpecRegistry {
             return crdName.substring(beginIndex + 1, crdName.indexOf('.', beginIndex + 1));
         }
 
+        String getPlural() {
+            return getPlural(crdName);
+        }
+
+        static String getPlural(String crdName) {
+            final int endIndex = crdName.indexOf('.');
+            return crdName.substring(0, endIndex);
+        }
+
         boolean isUnvisited() {
             return !visited;
         }
@@ -188,6 +196,17 @@ public class IstioSpecRegistry {
         if (crd != null) {
             crd.visited = true;
             return Optional.of(crd.kind);
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    public static Optional<String> getIstioKindPlural(String simpleClassName) {
+        final String key = getCRDKeyFrom(simpleClassName);
+
+        CRDInfo crd = crdInfos.get(key);
+        if (crd != null) {
+            return Optional.of(crd.getPlural());
         } else {
             return Optional.empty();
         }

--- a/istio-model-annotator/src/main/java/me/snowdrop/istio/annotator/IstioTypeAnnotator.java
+++ b/istio-model-annotator/src/main/java/me/snowdrop/istio/annotator/IstioTypeAnnotator.java
@@ -101,7 +101,8 @@ public class IstioTypeAnnotator extends Jackson2Annotator {
         final Optional<String> kind = IstioSpecRegistry.getIstioKind(clazz.name());
         if (kind.isPresent()) {
             clazz._implements(IstioSpec.class);
-            clazz.annotate(IstioKind.class).param("name", kind.get());
+            final String plural = IstioSpecRegistry.getIstioKindPlural(clazz.name()).orElse(kind + "s");
+            clazz.annotate(IstioKind.class).param("name", kind.get()).param("plural", plural);
         }
         final Optional<String> version = IstioSpecRegistry.getIstioApiVersion(clazz.name());
         if (version.isPresent()) {

--- a/istio-model/src/main/resources/istio-resource.vm
+++ b/istio-model/src/main/resources/istio-resource.vm
@@ -43,16 +43,18 @@ import me.snowdrop.istio.api.internal.IstioKind;
 #end
 
 #set ($kind = "$resource")
+#set ($plural = "$kind" + "s")
 #foreach ($annotation in $annotations)
     #if ($annotation.getClassRef().getName().equals("IstioKind"))
         #set ($kind = $annotation.getParameters().get("name"))
+        #set ($plural = $annotation.getParameters().get("plural"))
     #end
 #end
 /**
  *
  *
  */
-@IstioKind(name = "$kind")
+@IstioKind(name = "$kind", plural = "$plural")
 @IstioApiVersion("$version")
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Generated("org.jsonschema2pojo")


### PR DESCRIPTION
With the previous implementation plurals (which determine the API path
that the Kubernetes Client uses) where handled by simply appending an
"s" to the name of the class. This fails for a number of CRD, like
Policy.
We now use the information that is present in the crdName
during the Operations generation