### PR TITLE
Fix maven compile error in windows

### DIFF
--- a/istio-model-annotator/src/main/java/me/snowdrop/istio/annotator/IstioTypeAnnotator.java
+++ b/istio-model-annotator/src/main/java/me/snowdrop/istio/annotator/IstioTypeAnnotator.java
@@ -130,7 +130,7 @@ public class IstioTypeAnnotator extends Jackson2Annotator {
             arrayMember.annotate(VelocityTransformation.class).param("value", "/istio-resource.vm");
             arrayMember.annotate(VelocityTransformation.class).param("value", "/istio-resource-list.vm");
             arrayMember.annotate(VelocityTransformation.class).param("value", "/istio-manifest.vm").param("outputPath", "crd.properties").param("gather", true);
-            arrayMember.annotate(VelocityTransformation.class).param("value", "/istio-mappings-provider.vm").param("outputPath", "me/snowdrop/istio/api/model/IstioResourceMappingsProvider.java").param("gather", true);
+            arrayMember.annotate(VelocityTransformation.class).param("value", "/istio-mappings-provider.vm").param("outputPath", "me" + File.separator + "snowdrop" + File.separator + "istio" + File.separator + "api" + File.separator + "model" + File.separator + "IstioResourceMappingsProvider.java").param("gather", true);
         }
     }
 


### PR DESCRIPTION
Fix maven compile error in windows caused by file separator, replace '/' to File.separator