### PR TITLE
Remove dependency on com.sun:tools

### DIFF
--- a/istio-client/pom.xml
+++ b/istio-client/pom.xml
@@ -35,6 +35,12 @@
       <groupId>io.sundr</groupId>
       <artifactId>builder-annotations</artifactId>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.sun</groupId>
+          <artifactId>tools</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.sundr</groupId>

--- a/istio-client/pom.xml
+++ b/istio-client/pom.xml
@@ -100,6 +100,21 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>jdk9</id>
+      <activation>
+        <jdk>[1,1.9)</jdk>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>com.sun</groupId>
+          <artifactId>tools</artifactId>
+          <version>1.7</version>
+          <scope>system</scope>
+          <systemPath>${java.home}/../lib/tools.jar</systemPath>
+        </dependency>
+      </dependencies>
+    </profile>
   </profiles>
 
 </project>

--- a/istio-model-annotator/pom.xml
+++ b/istio-model-annotator/pom.xml
@@ -45,4 +45,21 @@
             <version>${lombok.version}</version>
         </dependency>
     </dependencies>
+    <profiles>
+        <profile>
+            <id>jdk9</id>
+            <activation>
+                <jdk>[1,1.9)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.sun</groupId>
+                    <artifactId>tools</artifactId>
+                    <version>1.7</version>
+                    <scope>system</scope>
+                    <systemPath>${java.home}/../lib/tools.jar</systemPath>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>

--- a/istio-model-annotator/pom.xml
+++ b/istio-model-annotator/pom.xml
@@ -22,6 +22,12 @@
             <groupId>io.sundr</groupId>
             <artifactId>builder-annotations</artifactId>
             <scope>compile</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.sun</groupId>
+                    <artifactId>tools</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.sundr</groupId>

--- a/istio-model-annotator/src/main/java/me/snowdrop/istio/annotator/IstioTypeAnnotator.java
+++ b/istio-model-annotator/src/main/java/me/snowdrop/istio/annotator/IstioTypeAnnotator.java
@@ -7,6 +7,7 @@
 package me.snowdrop.istio.annotator;
 
 import java.io.Serializable;
+import java.nio.file.Paths;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
@@ -129,8 +130,12 @@ public class IstioTypeAnnotator extends Jackson2Annotator {
                     .paramArray("value");
             arrayMember.annotate(VelocityTransformation.class).param("value", "/istio-resource.vm");
             arrayMember.annotate(VelocityTransformation.class).param("value", "/istio-resource-list.vm");
-            arrayMember.annotate(VelocityTransformation.class).param("value", "/istio-manifest.vm").param("outputPath", "crd.properties").param("gather", true);
-            arrayMember.annotate(VelocityTransformation.class).param("value", "/istio-mappings-provider.vm").param("outputPath", "me/snowdrop/istio/api/model/IstioResourceMappingsProvider.java").param("gather", true);
+            arrayMember.annotate(VelocityTransformation.class).param("value", "/istio-manifest.vm")
+                    .param("outputPath", "crd.properties").param("gather", true);
+            arrayMember.annotate(VelocityTransformation.class).param("value", "/istio-mappings-provider.vm")
+                    .param("outputPath", Paths.get("me", "snowdrop", "istio", "api", "model",
+                            "IstioResourceMappingsProvider.java").toString())
+                    .param("gather", true);
         }
     }
 

--- a/istio-model/pom.xml
+++ b/istio-model/pom.xml
@@ -69,6 +69,12 @@
       <groupId>io.sundr</groupId>
       <artifactId>builder-annotations</artifactId>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.sun</groupId>
+          <artifactId>tools</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.sundr</groupId>

--- a/istio-model/pom.xml
+++ b/istio-model/pom.xml
@@ -108,7 +108,23 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
+  <profiles>
+    <profile>
+      <id>jdk9</id>
+      <activation>
+        <jdk>[1,1.9)</jdk>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>com.sun</groupId>
+          <artifactId>tools</artifactId>
+          <version>1.7</version>
+          <scope>system</scope>
+          <systemPath>${java.home}/../lib/tools.jar</systemPath>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
   <build>
     <plugins>
       <plugin>


### PR DESCRIPTION
Remove dependency 'com.sun:tools' which cause 'Missing artifact com.sun.java:tools:jar' in maven compile process when JDK 9 or higher version