### PR TITLE
fix consistent hash typo

### DIFF
--- a/istio-common/src/main/resources/classes-with-interface-fields.yml
+++ b/istio-common/src/main/resources/classes-with-interface-fields.yml
@@ -18,7 +18,7 @@ classes:
   - class: me.snowdrop.istio.api.networking.v1alpha3.LoadBalancerSettings
     fields:
       simple: isLoadBalancerSettings_LbPolicy
-      consitentHash: isLoadBalancerSettings_LbPolicy
+      consistentHash: isLoadBalancerSettings_LbPolicy
   - class: me.snowdrop.istio.api.networking.v1alpha3.PortSelector
     fields:
       name: isPortSelector_Port


### PR DESCRIPTION
consistenthash class is not generated since the typo